### PR TITLE
Add login and registration sections to demo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
         <button id="themeToggle" class="btn">Toggle Theme</button>
       </div>
     </nav>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Typography</h2>
@@ -26,12 +27,14 @@
       <p>Dette er et avsnitt som viser font-size, line-height og marginer.</p>
       <a href="#">En lenke med rammeverksfarger</a>
     </section>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Buttons</h2>
       <button class="btn bg-primary">Primær knapp</button>
       <button class="btn bg-alt mt-1 mb-1">Sekundær knapp</button>
     </section>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Grid System</h2>
@@ -47,6 +50,7 @@
         </div>
       </div>
     </section>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Forms</h2>
@@ -60,16 +64,51 @@
       </div>
       <button class="btn">Send</button>
     </section>
+    <hr class="section-divider" />
+
+    <section class="container mt-2">
+      <h2 class="h2">Login</h2>
+      <div class="form-group">
+        <label for="loginEmail">Email</label>
+        <input id="loginEmail" type="email" placeholder="you@example.com" />
+      </div>
+      <div class="form-group">
+        <label for="loginPassword">Password</label>
+        <input id="loginPassword" type="password" />
+      </div>
+      <button class="btn">Login</button>
+    </section>
+    <hr class="section-divider" />
+
+    <section class="container mt-2">
+      <h2 class="h2">Create Account</h2>
+      <div class="form-group">
+        <label for="regName">Name</label>
+        <input id="regName" type="text" placeholder="Jane Doe" />
+      </div>
+      <div class="form-group">
+        <label for="regEmail">Email</label>
+        <input id="regEmail" type="email" placeholder="you@example.com" />
+      </div>
+      <div class="form-group">
+        <label for="regPassword">Password</label>
+        <input id="regPassword" type="password" />
+      </div>
+      <button class="btn">Create Account</button>
+    </section>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Utilities</h2>
       <div class="bg-light p-2 mt-1">Bakgrunn med padding og margin</div>
     </section>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Code Block</h2>
       <pre><code>console.log('Hello world');</code></pre>
     </section>
+    <hr class="section-divider" />
 
     <section class="container mt-2">
       <h2 class="h2">Modal Component</h2>

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -40,3 +40,10 @@ button:hover {
 .form-group {
   margin-bottom: 1rem;
 }
+
+/* Divider */
+.section-divider {
+  border: 0;
+  border-top: 1px solid var(--color-secondary);
+  margin: 2rem 0;
+}


### PR DESCRIPTION
## Summary
- add section divider component
- show dividers between demo sections
- add login and create account forms to the demo page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f7957ff348329ace57c007f15be8b