### PR TITLE
Add theme variable for card background

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -11,6 +11,7 @@
 
   --color-bg: #fdfdfd;
   --color-text: #222;
+  --color-card-bg: #fff;
   --radius: 0.5rem;
 }
 
@@ -21,6 +22,7 @@
   --color-primary: #0d6efd;
   --color-secondary: #6c757d;
   --color-alternative: #20c997;
+  --color-card-bg: #333;
 }
 
 * {

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -18,7 +18,8 @@ button:hover {
   border: 1px solid #ddd;
   border-radius: var(--radius);
   padding: 1rem;
-  background: #fff;
+  background: var(--color-card-bg);
+  color: var(--color-text);
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
 }
 


### PR DESCRIPTION
## Summary
- extract card background color into `--color-card-bg`
- define a darker card background for `.dark-mode`
- keep text readable by inheriting `--color-text`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f788541308329bb4e6f000d5fa698