### PR TITLE
Add configurable input background variable

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -11,6 +11,8 @@
 
   --color-bg: #fdfdfd;
   --color-text: #222;
+  --color-input-bg: #fff;
+  --color-input-border: #ccc;
   --radius: 0.5rem;
 }
 
@@ -21,6 +23,8 @@
   --color-primary: #0d6efd;
   --color-secondary: #6c757d;
   --color-alternative: #20c997;
+  --color-input-bg: #333;
+  --color-input-border: #555;
 }
 
 * {
@@ -41,10 +45,10 @@ input,
 textarea,
 select {
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-input-border);
   border-radius: var(--radius);
   font: inherit;
-  background-color: #fff;
+  background-color: var(--color-input-bg);
   color: inherit;
 }
 


### PR DESCRIPTION
## Summary
- use `--color-input-bg` in base CSS forms
- set input background & border vars for light and dark modes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f788674a08329b13416770b425e7b