### PR TITLE
Add code block background variable

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -11,6 +11,7 @@
 
   --color-bg: #fdfdfd;
   --color-text: #222;
+  --color-code-bg: #f8f9fa;
   --radius: 0.5rem;
 }
 
@@ -18,6 +19,7 @@
 .dark-mode {
   --color-bg: #222;
   --color-text: #fdfdfd;
+  --color-code-bg: #343a40;
   --color-primary: #0d6efd;
   --color-secondary: #6c757d;
   --color-alternative: #20c997;

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -25,7 +25,7 @@ a {
 }
 
 pre {
-  background: #f8f9fa;
+  background: var(--color-code-bg);
   padding: 1rem;
   overflow-x: auto;
   border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- add `--color-code-bg` variables in light and dark themes
- use the new variable in `typography.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f788815008329870a546658523d47