### PR TITLE
Implement persistent dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ utility classes, a simple grid system, basic components and a small demo.
 - Simple JavaScript helpers for modals and theme switching
 
 Open `public/index.html` to preview the components.
+
+## Theme Preference
+
+The framework stores your theme choice in `localStorage`. On first load it will
+fall back to your operating system preference using `prefers-color-scheme`.
+Toggle the theme with the button in `index.html` to save your preference.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -6,10 +6,19 @@ document.addEventListener("DOMContentLoaded", () => {
   // You can initialize components here, e.g.:
   // initModal();
 
+  // Theme setup
+  const savedTheme = localStorage.getItem("theme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+    document.body.classList.add("dark-mode");
+  }
+
   const toggle = document.getElementById("themeToggle");
   if (toggle) {
     toggle.addEventListener("click", () => {
       document.body.classList.toggle("dark-mode");
+      const theme = document.body.classList.contains("dark-mode") ? "dark" : "light";
+      localStorage.setItem("theme", theme);
     });
   }
 });


### PR DESCRIPTION
## Summary
- preserve the chosen theme in localStorage
- fall back to `prefers-color-scheme` on first load
- document theme preference behavior

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f7889da90832992d7986a4a026e81